### PR TITLE
OT-FocusVibration | Added vibration for when the focus score is false

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.VIBRATE" />
     <!-- io.flutter.app.FlutterApplication is an android.app.Application that
          calls FlutterMain.startInitialization(this); in its onCreate method.
          In most cases you can leave this as-is, but you if you want to provide

--- a/lib/components/footer/bottomNavigationTabs.dart
+++ b/lib/components/footer/bottomNavigationTabs.dart
@@ -4,6 +4,7 @@ import 'package:off_top_mobile/recordingSession.dart';
 import 'package:off_top_mobile/reports.dart';
 import 'package:off_top_mobile/settingsPage.dart';
 
+
 class BottomNavigationTabs extends StatelessWidget {
   const BottomNavigationTabs(this.homePage);
   final Widget homePage;

--- a/lib/components/recordingSession/meter.dart
+++ b/lib/components/recordingSession/meter.dart
@@ -3,6 +3,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:off_top_mobile/components/recordingSession/websocket.dart';
 import 'package:syncfusion_flutter_gauges/gauges.dart';
+import 'package:off_top_mobile/components/recordingSession/vibration.dart';
+import 'package:vibration/vibration.dart';
 
 class Meter extends StatefulWidget {
   const Meter({Key key, @required this.ws}) : super(key: key);
@@ -18,8 +20,11 @@ class MeterState extends State<Meter> {
   double meterScore = 50;
   MyWebSocket ws;
 
+CustomVibration vibrate;
+
   @override
   void initState() {
+    vibrate = CustomVibration();
     ws = widget.ws;
     ws.channel.stream.listen(
       (dynamic onData) {
@@ -36,6 +41,7 @@ class MeterState extends State<Meter> {
       () {
         if (5 <= meterScore && !isOnTopic) {
           meterScore -= 5;
+          vibrate.PatternVibrate();
         } else if (isOnTopic && meterScore <= 95) {
           meterScore += 5;
         }

--- a/lib/components/recordingSession/meter.dart
+++ b/lib/components/recordingSession/meter.dart
@@ -19,8 +19,7 @@ class MeterState extends State<Meter> {
   bool isOnTopic;
   double meterScore = 50;
   MyWebSocket ws;
-
-CustomVibration vibrate;
+  CustomVibration vibrate;
 
   @override
   void initState() {
@@ -35,6 +34,7 @@ CustomVibration vibrate;
     );
     super.initState();
   }
+
 
   void updateScore(bool isOnTopic) {
     setState(

--- a/lib/components/recordingSession/vibration.dart
+++ b/lib/components/recordingSession/vibration.dart
@@ -1,0 +1,23 @@
+import 'package:vibration/vibration.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart'; // we need this for the vibrations
+import 'dart:io'; // we need this for the sleep method
+
+
+class CustomVibration {
+
+  PatternVibrate() {
+    HapticFeedback.mediumImpact();
+ 
+    sleep(
+      const Duration(milliseconds: 400),
+    );
+
+    print('medium impact vibration');
+
+
+
+  }
+}

--- a/lib/components/recordingSession/vibration.dart
+++ b/lib/components/recordingSession/vibration.dart
@@ -10,14 +10,9 @@ class CustomVibration {
 
   PatternVibrate() {
     HapticFeedback.mediumImpact();
- 
     sleep(
       const Duration(milliseconds: 400),
     );
-
-    print('medium impact vibration');
-
-
-
+    print('Read Low Focus Score');
   }
 }

--- a/lib/recordingSession.dart
+++ b/lib/recordingSession.dart
@@ -3,7 +3,6 @@ import 'package:off_top_mobile/components/recordingSession/meter.dart';
 import 'package:off_top_mobile/components/offTopTitle.dart';
 import 'package:off_top_mobile/components/recordingSession/recorder.dart';
 import 'package:off_top_mobile/components/recordingSession/websocket.dart';
-
 import 'components/subnavbar.dart';
 
 class RecordingPage extends StatefulWidget {

--- a/lib/reports.dart
+++ b/lib/reports.dart
@@ -35,3 +35,4 @@ class _ReportsState extends State<ReportsPage> {
     )));
   }
 }
+

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,6 +35,7 @@ dependencies:
   firebase_auth: ^0.16.1
   modal_progress_hud: ^0.1.3
   font_awesome_flutter: ^8.8.1
+  vibration: ^1.4.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
**What I did**: To be able to trigger a vibration and print statement when the focus score is false.

**How to test**: 
-Have the off-top app running
-Have producer.py in off-top-python running
-Start recording so the app can get your focus score. The emulator itself will not show vibration unless you are testing it on a real device, but I've added a print statement so when the focus score is false, it will print out "medium impact vibration" in the off-top-flutter terminal.
![Screenshot (44)](https://user-images.githubusercontent.com/55634110/87217677-c1610a00-c300-11ea-8ef6-d065b1ca905b.png)
![Screenshot (45)](https://user-images.githubusercontent.com/55634110/87217679-c45bfa80-c300-11ea-8958-098ec92151ec.png)
